### PR TITLE
refactor: use GNUInstallDirs and & link against CoreFoundation/Security on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,19 @@ add_library(certify::core ALIAS core)
 target_compile_features(core INTERFACE cxx_std_11)
 
 target_include_directories(core INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
 if(MSVC)
 	target_link_libraries(core INTERFACE Crypt32.lib)
 endif()
+
+if (APPLE)
+    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+    find_library(SECURITY_LIBRARY Security)
+    target_link_libraries(core INTERFACE ${COREFOUNDATION_LIBRARY} ${SECURITY_LIBRARY})
+endif ()
 
 target_link_libraries(
     core
@@ -54,27 +60,29 @@ target_link_libraries(
         OpenSSL::Crypto)
 
 include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 write_basic_package_version_file(
-    "certifyConfigVersion.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/certifyConfigVersion.cmake"
     COMPATIBILITY AnyNewerVersion)
 
 install(FILES
-            "certifyConfig.cmake"
-            "${CMAKE_BINARY_DIR}/certifyConfigVersion.cmake"
-        DESTINATION lib/cmake/certify)
+            "${CMAKE_CURRENT_BINARY_DIR}/certifyConfig.cmake"
+            "${CMAKE_CURRENT_BINARY_DIR}/certifyConfigVersion.cmake"
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/certify)
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-        DESTINATION include
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 	FILES_MATCHING PATTERN "*.hpp" PATTERN "*.ipp")
 
 install(TARGETS core
         EXPORT certifyTargets
-        INCLUDES DESTINATION include)
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(EXPORT certifyTargets
         FILE certifyTargets.cmake
         NAMESPACE certify::
-        DESTINATION lib/cmake/certify)
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/certify)
 
 include(CTest)
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ write_basic_package_version_file(
 install(FILES
             "${CMAKE_CURRENT_SOURCE_DIR}/certifyConfig.cmake"
             "${CMAKE_CURRENT_BINARY_DIR}/certifyConfigVersion.cmake"
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/certify)
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/certify)
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -82,7 +82,7 @@ install(TARGETS core
 install(EXPORT certifyTargets
         FILE certifyTargets.cmake
         NAMESPACE certify::
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/certify)
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/certify)
 
 include(CTest)
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion)
 
 install(FILES
-            "${CMAKE_CURRENT_BINARY_DIR}/certifyConfig.cmake"
+            "${CMAKE_CURRENT_SOURCE_DIR}/certifyConfig.cmake"
             "${CMAKE_CURRENT_BINARY_DIR}/certifyConfigVersion.cmake"
         DESTINATION ${CMAKE_INSTALL_DATADIR}/certify)
 


### PR DESCRIPTION
This PR makes certify properly support installation via CMake. It:
- aligns its installation directories with those used by the LaunchDarkly C++ SDKs (`via GNUInstallDirs`)
- adds support for building on MacOS
- uses relative directories when building (`CMAKE_CURRENT_SOURCE_DIR` vs ` CMAKE_SOURCE_DIR`, so that it supports being pulled in via FetchContent