### PR TITLE
feat: Update to boost 1.69 and remove system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,6 @@ endif ()
 target_link_libraries(
     core
     INTERFACE
-        Boost::system
         Boost::filesystem
         Boost::date_time
         Threads::Threads

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,8 @@ if (CMAKE_VERSION VERSION_LESS 3.11)
     list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_BINARY_DIR}/cmake)
 endif()
 
-find_package(Boost 1.67
+find_package(Boost 1.69
              COMPONENTS
-                system
                 filesystem
                 date_time
                 unit_test_framework


### PR DESCRIPTION
Since boost 1.69 system has been header only and doesn't require linking a library.
As of 1.87 it cannot be linked anymore.